### PR TITLE
Fix bindingNeedSubscribe logic for multiple bindings in one entry

### DIFF
--- a/widgets/materialdesign/js/widgets/materialdesign.00.helper.js
+++ b/widgets/materialdesign/js/widgets/materialdesign.00.helper.js
@@ -585,7 +585,7 @@ vis.binds.materialdesign.helper = {
                 let view = vis.binds.materialdesign.helper.getViewOfWidget(wid);
 
                 if (vis.bindings.hasOwnProperty(bindings[b].systemOid) === false) {
-                    result.oidNeedSubscribe = vis.binds.materialdesign.helper.oidNeedSubscribe(bindings[b].systemOid, wid, widgetName, oidNeedSubscribe, true);
+                    result.oidNeedSubscribe = vis.binds.materialdesign.helper.oidNeedSubscribe(bindings[b].systemOid, wid, widgetName, result.oidNeedSubscribe, true);
 
                     vis.bindings[[bindings[b].systemOid]] = [{
                         visOid: bindings[b].visOid,
@@ -606,7 +606,7 @@ vis.binds.materialdesign.helper = {
                         if (bindings[b].operations[o].arg) {
                             for (var a = 0; a <= bindings[b].operations[o].arg.length - 1; a++) {
                                 if (bindings[b].operations[o].arg[a].systemOid) {
-                                    result.oidNeedSubscribe = vis.binds.materialdesign.helper.oidNeedSubscribe(bindings[b].operations[o].arg[a].systemOid, wid, widgetName, oidNeedSubscribe, true);
+                                    result.oidNeedSubscribe = vis.binds.materialdesign.helper.oidNeedSubscribe(bindings[b].operations[o].arg[a].systemOid, wid, widgetName, result.oidNeedSubscribe, true);
                                 }
                             }
                         }

--- a/widgets/materialdesign/js/widgets/materialdesign.00.helper.js
+++ b/widgets/materialdesign/js/widgets/materialdesign.00.helper.js
@@ -584,10 +584,20 @@ vis.binds.materialdesign.helper = {
 
                 let view = vis.binds.materialdesign.helper.getViewOfWidget(wid);
 
-                if (vis.bindings.hasOwnProperty(bindings[b].systemOid) === false) {
+                let needsSubscribe = true;
+                if (vis.bindings.hasOwnProperty(bindings[b].systemOid) === true) {
+                    for (var i = 0; i < vis.bindings[bindings[b].systemOid].length; i++) {
+                        if (vis.bindings[bindings[b].systemOid][i].widget == wid) {
+                            needsSubscribe = false;
+                            break;
+                        }
+                    }
+                }
+                if (needsSubscribe === true) {
                     result.oidNeedSubscribe = vis.binds.materialdesign.helper.oidNeedSubscribe(bindings[b].systemOid, wid, widgetName, result.oidNeedSubscribe, true);
 
-                    vis.bindings[[bindings[b].systemOid]] = [{
+                    vis.bindings[bindings[b].systemOid] = vis.bindings[bindings[b].systemOid] || []
+                    vis.bindings[bindings[b].systemOid].push({
                         visOid: bindings[b].visOid,
                         systemOid: bindings[b].systemOid,
                         token: bindings[b].token,
@@ -598,7 +608,7 @@ vis.binds.materialdesign.helper = {
                         view: view,
                         widget: wid,
                         attr: 'none'
-                    }]
+                    })
                 }
 
                 if (bindings[b].operations) {


### PR DESCRIPTION
Currently I have some issues regarding initial resolution and later updates of bindings (I mostly use JSON lists).
1. One of them (regarding later updates) I recently described in the forum:
For the JSON list
```json
[{
  "text":"{0_userdata.0.a}",
    "subText":"{0_userdata.0.a.ts}"
}]
```
both text and subText are displayed correctly during the first page loading, but when the page remains open only the subText is being updated on changes of the datapoint.

2. The following JSON list has already problems at first page loading:
```json
[{
    "text": "{t:mqtt-client.0.weather.outTemp_C;t.toString()}",
    "rightText": "{t:mqtt-client.0.weather.outTemp_C.ts;t.toString()}"
}]
```
`mqtt-client.0.weather.outTemp_C` is replaced by null, which can be seen in the browser console:
```
Error in eval[value]     : {t:mqtt-client.0.weather.outTemp_C;t.toString()} vis.js:2514:41
Error in eval[script]: var t = JSON.parse("null");return t.toString(); vis.js:2515:41
Error in eval[error] : TypeError: t is null vis.js:2516:41
```
While "text" always shows as "0", "rightText" shows the correct value.

Since I'm new to the project, I'm not quite sure about the complete loading process, but looking at the code I found that bindingNeedSubscribe seems to have a bug which might related to the issues I encounter.